### PR TITLE
Fixed issue with media formatters

### DIFF
--- a/src/SDammann.WebApi.Versioning/VersionedApiExplorer.cs
+++ b/src/SDammann.WebApi.Versioning/VersionedApiExplorer.cs
@@ -166,17 +166,22 @@ namespace SDammann.WebApi.Versioning
 
             foreach (HttpMethod method in supportedMethods)
             {
-                apiDescriptions.Add(new VersionedApiDescription()
+                var description = new ApiDescription()
                 {
                     Documentation = apiDocumentation,
                     HttpMethod = method,
                     RelativePath = finalPath,
                     ActionDescriptor = actionDescriptor,
-                    Route = route,
-                    SupportedResponseFormatters = new Collection<MediaTypeFormatter>(supportedResponseFormatters.ToList()),
-                    SupportedRequestBodyFormatters = new Collection<MediaTypeFormatter>(supportedRequestBodyFormatters.ToList()),
-                    ParameterDescriptions = new Collection<ApiParameterDescription>(parameterDescriptions)
-                });
+                    Route = route
+                };
+                foreach(var mtf in supportedRequestBodyFormatters)
+                    description.SupportedRequestBodyFormatters.Add(mtf);
+                foreach(var mtf in supportedResponseFormatters)
+                    description.SupportedResponseFormatters.Add(mtf);
+                foreach(var par in parameterDescriptions)
+                    description.ParameterDescriptions.Add(par);
+
+                apiDescriptions.Add(description);
             }
         }
 
@@ -339,19 +344,5 @@ namespace SDammann.WebApi.Versioning
             }
             return version;
         }
-    }
-
-    internal class VersionedApiDescription : ApiDescription
-    {
-        public VersionedApiDescription()
-        {
-            SupportedRequestBodyFormatters = new Collection<MediaTypeFormatter>();
-            SupportedResponseFormatters = new Collection<MediaTypeFormatter>();
-            ParameterDescriptions = new Collection<ApiParameterDescription>();
-        }
-        
-        public new Collection<MediaTypeFormatter> SupportedResponseFormatters { get; internal set; }
-        public new Collection<MediaTypeFormatter> SupportedRequestBodyFormatters { get; internal set; }
-        public new Collection<ApiParameterDescription> ParameterDescriptions { get; internal set; }
     }
 }


### PR DESCRIPTION
The media formatters were always 0 because of the implementation of VersionedFormatter.  Changed how the original code was written; they now report correctly.

To verify, I ran this through with the Auto-help generator in Nuget and it was able to parse the whole API.
