### PR TITLE
Make help page can be compatible with legacy controllers that don't have any versioning namespace.

### DIFF
--- a/src/VersioningTestApp/App_Start/RouteConfig.cs
+++ b/src/VersioningTestApp/App_Start/RouteConfig.cs
@@ -14,11 +14,11 @@
                                 defaults: new { id = RouteParameter.Optional }
                     );
 
-            //routes.MapHttpRoute(
-            //        name: "DefaultApi",
-            //        routeTemplate: "api/{controller}/{id}",
-            //        defaults: new { id = RouteParameter.Optional }
-            //);
+            routes.MapHttpRoute(
+                    name: "DefaultApi without version",
+                    routeTemplate: "api/{controller}/{id}",
+                    defaults: new { id = RouteParameter.Optional }
+            );
 
             routes.MapRoute(
                             name: "Default",

--- a/src/VersioningTestApp/Controllers/HelloController.cs
+++ b/src/VersioningTestApp/Controllers/HelloController.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using VersioningTestApp.Api;
+
+namespace VersioningTestApp.Controllers
+{
+    public class HelloController : ApiController
+    {
+        /// <summary>
+        /// Gets an fine greeting from the controller
+        /// </summary>
+        /// <remarks>Bogus documentation that will turn up in the generate documentation pages.</remarks>
+        /// <returns></returns>
+        public Message Get()
+        {
+            return new Message("Hello World from General API without version!", "Hello World");
+        }
+    }
+}

--- a/src/VersioningTestApp/VersioningTestApp.csproj
+++ b/src/VersioningTestApp/VersioningTestApp.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Areas\HelpPage\SampleGeneration\SampleDirection.cs" />
     <Compile Include="Areas\HelpPage\SampleGeneration\TextSample.cs" />
     <Compile Include="Areas\HelpPage\XmlDocumentationProvider.cs" />
+    <Compile Include="Controllers\HelloController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>


### PR DESCRIPTION
1. Legacy controllers without any versioning namespace cannot be displayed in help page properly.
2. Adjust VersionedApiExplorer class to take these legacy controllers into consideration.
3. Modify demo web site to present these cases.
