### PR TITLE
Fix for issue #34

### DIFF
--- a/src/SDammann.WebApi.Versioning/VersionedApiExplorer.cs
+++ b/src/SDammann.WebApi.Versioning/VersionedApiExplorer.cs
@@ -301,7 +301,7 @@ namespace SDammann.WebApi.Versioning
             foreach (var paramDescriptor in parameterDescriptions.Where(pd => pd.Source == ApiParameterSource.FromUri))
             {
                 Type parameterType = paramDescriptor.ParameterDescriptor.ParameterType;
-                if (parameterType.IsPrimitive || parameterType == typeof(string) || parameterType == typeof(Nullable<>))
+                if (parameterType.Namespace == "System")
                 {
                     parameterValuesForRoute.Add(paramDescriptor.Name, "{" + paramDescriptor.Name + "}");
                 }


### PR DESCRIPTION
parameterType == typeof(Nullable<>) wasn't satisfied by nullable
parameters. Each nullable parameterType was then passed to
GetModelParameterValues where the properties "HasValue" and "Value" were
added to the parameterValuesForRoute dictionary. Any route with multiple
nullable parameters ran into "ArgumentException: An item with the same
key has already been added" because "HasValue" was already in the
dictionary when the second nullable parameterType was passed to
GetModelParameterValues.

Fixed by modifying the if statement in question to be satisfied by all
built-in types.
