### PR TITLE
Pass the inner exception when catching an exception while  creating a ne...

### DIFF
--- a/src/SDammann.WebApi.Versioning/Internal/ServicesExtensions.cs
+++ b/src/SDammann.WebApi.Versioning/Internal/ServicesExtensions.cs
@@ -59,9 +59,9 @@
                 try {
                     service = Activator.CreateInstance(clrType) as TService;
                 }
-                catch (Exception) {
+                catch (Exception ex) {
                     throw new InvalidOperationException(
-                        String.Format(ExceptionResources.DependencyContainerNotConfigured, clrType.FullName));
+                        String.Format(ExceptionResources.DependencyContainerNotConfigured, clrType.FullName), ex);
                 }
             }
 


### PR DESCRIPTION
Pass the inner exception when catching an exception while  creating a new service (for debugging)

This helps when debugging issues with the IOC container.